### PR TITLE
Use Bundler for gem management

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org' do
+    gem 'sinatra', '~>2.0'
+    gem 'dbi', '~>0.4.5'
+    gem 'dbd-mysql', '~>0.4.4'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,31 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    dbd-mysql (0.4.4)
+      dbi (>= 0.4.0)
+      mysql
+    dbi (0.4.5)
+      deprecated (= 2.0.1)
+    deprecated (2.0.1)
+    mustermann (1.0.0)
+    mysql (2.9.1)
+    rack (2.0.1)
+    rack-protection (2.0.0)
+      rack
+    sinatra (2.0.0)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.0)
+      tilt (~> 2.0)
+    tilt (2.0.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  dbd-mysql (~> 0.4.4)!
+  dbi (~> 0.4.5)!
+  sinatra (~> 2.0)!
+
+BUNDLED WITH
+   1.14.4

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ To find out scores, just send the message `!karma` followed by any number of wor
 #### Prerequisites
 1. Your own box
 2. Ruby
-3. [Sinatra](http://www.sinatrarb.com/)
-4. [Ruby MySQL DBI](http://ruby-dbi.rubyforge.org/)
+3. A MySQL database
 
 #### What to do
 1. Fork this repo to your server. The main files you need are:
@@ -46,4 +45,6 @@ To find out scores, just send the message `!karma` followed by any number of wor
    1. `thing` a text field
    2. `points` an int
 6. Create a `tokens.rb` file that contains your db table names and app authentication tokens (copy tokens.rb.SAMPLE)
-7. Restart your sinatra server and you're good to go!
+7. Install Bundler: `gem install bundler`
+8. Install dependencies: `bundle install --deployment` (to develop, run `bundle install --path=vendor/bundle` instead)
+9. Run the server: `bundle exec rackup -p$PORT -o$HOST config.ru` and you're good to go!


### PR DESCRIPTION
Declare dependencies in Gemfile and modify instructions to use
Bundler. This will improve the reproducibility of the install
instructions.

This and other changes will make `slack-karmabot` eventually
deployable to Heroku or another platform-as-a-service #9 .